### PR TITLE
Improve SSL compatibility

### DIFF
--- a/includes/class-bwp-minify.php
+++ b/includes/class-bwp-minify.php
@@ -599,7 +599,16 @@ if (!empty($page))
 		if (0 === strpos($src, 'http'))
 		{
 			// We will need to handle both http and https, even if site URL is still set to http
-			$tmp_src = str_replace(site_url(), '', $src);
+			$site_url = site_url();
+			if (0 === strpos($src, 'https'))
+			{
+				$src = str_replace('https', 'http', $src);
+			}
+			if (0 === strpos($site_url, 'https'))
+			{
+				$site_url = str_replace('https', 'http', $site_url);
+			}
+			$tmp_src = str_replace( $site_url, '', $src );
 			// If there was no difference between tmp_src and src, we need to loop through the base
 			if ($tmp_src == $src && !empty($this->base))
 			{


### PR DESCRIPTION
Well, all of this started in the [WordPress support forum](http://wordpress.org/support/topic/improve-ssl-compatibility?replies=5#post-4891622), but I'm gonna repeat my description here in order to keep the pull request as much documented as I can.

I recently noticed an issue when logged-in users are forced to use SSL, but not scripts are not (i.e., `site_url()` returns https://mysite.com, but `get_stylesheet_directory_uri()` returns http://mysite.com/wp-content/themes/mytheme). In such cases, the `process_media_source()` method won't return the correct output (it will be something like http:/mysite.com/wp-content/themes/mythemestyle.css instead of /wp-content/themes/mythemestyle.css), so minification will not happen either. A typical situation could consist in a filter being applied to `site_url()`, forcing it to always use HTTPS as scheme, or having `FORCE_SSL_LOGIN` set to true in _wp-config.php_.

In my own environment, I was able to solve this issue by modifying some lines from `process_media_source`, found into _includes/class-bwp-minify.php_. More exactly, I replaced this:

``` PHP
$tmp_src = str_replace(site_url(), '', $src);
```

With this:

``` PHP
$site_url = site_url();
if (0 === strpos($src, 'https'))
{
    $src = str_replace('https', 'http', $src);
}
if (0 === strpos($site_url, 'https'))
{
    $site_url = str_replace('https', 'http', $site_url);
}
```

It would be great to know if this can be added to the actual plugin, since I'm not entirely sure that this fix won't trigger any other issue.

Again, you're doing a great piece of work here :)
