### PR TITLE
Replace deprecated get_theme_data with wp_get_theme function

### DIFF
--- a/includes/class-bwp-minify.php
+++ b/includes/class-bwp-minify.php
@@ -568,9 +568,10 @@ if (!empty($page))
 			break;
 
 			case 'tver':
-				$theme = get_theme_data(STYLESHEETPATH . '/style.css');
-				if (!empty($theme['Version']))
-					$buster = $theme['Version'];
+				$theme = wp_get_theme();
+				$buster = $theme->get( 'Version' );
+			break;
+
 			break;
 
 			case 'custom':


### PR DESCRIPTION
Class BWP_MINIFY uses the deprecated function get_theme_data, which causes a PHP notice. This patch replaces with the recommended function, wp_get_theme.

ps. thanks for an excellent plugin!
