### PR TITLE
pass item where items were passed; fixes #11

### DIFF
--- a/includes/class-bwp-enqueued-detector.php
+++ b/includes/class-bwp-enqueued-detector.php
@@ -399,8 +399,8 @@ class BWP_Enqueued_Detector
 				: __('footer', $this->_domain);
 		}
 
-		$min = isset($item['min']) && $item['min']; // minify needed
-		$wp = isset($item['wp']) && $item['wp']; // minify but print separately
+		$min = $item['min']; // minify needed
+		$wp = $item['wp']; // minify but print separately
 
 		if ($min)
 		{


### PR DESCRIPTION
Looks like the array of items was passed instead of single item.

Added tests for two optional `$item` keys: `min` and `wp`.
