### PR TITLE
Added hook to allow normal behavior on wp-login.php/wp-signup.php

### DIFF
--- a/includes/class-bwp-minify.php
+++ b/includes/class-bwp-minify.php
@@ -895,8 +895,10 @@ class BWP_MINIFY extends BWP_FRAMEWORK_IMPROVED
 		}
 
 		// collect js and css files to be combined and minified
-		if (false === strpos($_SERVER['REQUEST_URI'], 'wp-login.php')
-			&& false === strpos($_SERVER['REQUEST_URI'], 'wp-signup.php'))
+		$not_excluded = false === strpos($_SERVER['REQUEST_URI'], 'wp-login.php')
+			&& false === strpos($_SERVER['REQUEST_URI'], 'wp-signup.php');
+
+		if ( apply_filters('bwp_minify_not_excluded', $not_excluded ) )
 			// a priority of 1 makes BWP Minify compatible with plugins that
 			// use `template_redirect` hook to inject their own templates, such
 			// as BuddyPress.


### PR DESCRIPTION
We do run wp_head and wp_footer on our login page. This code resulted in our CSS and JS being completely stripped from these pages when we upgraded to 1.3.0. I added a hook here so that we can conditionally apply the normal concatenation/minification behavior on these pages:

```
add_filter( 'bwp_minify_not_excluded', function(){ return true; });
```
