### PR TITLE
added action bwp_minify_flushed_cache after cache is flushed

### DIFF
--- a/includes/class-bwp-minify.php
+++ b/includes/class-bwp-minify.php
@@ -2365,6 +2365,7 @@ class BWP_MINIFY extends BWP_FRAMEWORK_IMPROVED
 					}
 				}
 				closedir($dh);
+				do_action('bwp_minify_flushed_cache');
 			}
 		}
 


### PR DESCRIPTION
If wordpress is behind a CDN or caching proxy, it is nice to know if
the BWP cache is flushed, so that the upstream cache can be flushed
as well.
