### PR TITLE
Fixes #65: Correctly resolving directory traversal

### DIFF
--- a/includes/class-bwp-minify.php
+++ b/includes/class-bwp-minify.php
@@ -2676,8 +2676,22 @@ class BWP_MINIFY extends BWP_FRAMEWORK_IMPROVED
 			$src = $src[0];
 		}
 
+		 // Regex for resolving relative paths
+    	$regex = '#\/*[^/\.]+/\.\.#Uu';
+        while (preg_match($regex, $src)) {
+        	$src = preg_replace($regex, '', $src);
+    	}
+
+		// Remove remaining instances of '../'
+		$src = str_replace('../', '', $src);
+
+		// Resolve self-reference paths
 		$src = str_replace('./', '/', $src);
+
+		// Ensure same slash direction
 		$src = str_replace('\\', '/', $src);
+
+		// Reduce multiple slashes to single slash
 		$src = preg_replace('#[/]+#iu', '/', $src);
 		$src = ltrim($src, '/');
 


### PR DESCRIPTION
Fixes issue #65; directory traversal in a URL is now resolved when the file path is truncated for the minifier.

Affects `\BWP_MINIFY::process_media_source`.

`../` instances now get removed, including the directory immediately above.
`http://example.com/foo/bar/../baz.js` becomes `foo/baz.js`

Where traversal cannot be actioned (tries to go above the root), `../` instances are removed entirely.
`http://example.com/foo/../../bar.js` becomes `bar.js`

This behaviour mimics what most browsers do to URLs with similar directory traversal.

Previously these would not resolve correctly, simply replacing `../` with `./`, breaking paths.
