### PR TITLE
Config: let there be a filter

### DIFF
--- a/includes/class-bwp-minify.php
+++ b/includes/class-bwp-minify.php
@@ -2243,6 +2243,8 @@ class BWP_MINIFY extends BWP_FRAMEWORK_IMPROVED
 			'ini_set(\'zlib.output_compression\', \'0\')' => ''
 		);
 
+		$configs = apply_filters('bwp_minify_config', $configs);
+
 		$config_lines = array();
 		foreach ($configs as $config_key => $config_value)
 		{


### PR DESCRIPTION
Use case: hosts install some themes and plugins as symlinks for all of their hosted sites. Some of their hosted customers install bwp-minify and now their assets are all broken. The host can fix this for everyone by adding a must-use plugin that patches the config.
